### PR TITLE
Fix share text brand name

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -203,7 +203,7 @@ function fetchAndDisplayTerm(term) {
   // Generate share URLs
   // ================================
   const shareUrl = encodeURIComponent(`${window.location.origin}?term=${term}`);
-  const shareText = encodeURIComponent(`Check out this explanation of "${term}" on ExplainThisTech!`);
+  const shareText = encodeURIComponent(`Check out this explanation of "${term}" on Tech Decoded!`);
 
   const twitterShare = document.getElementById("twitterShare");
   const facebookShare = document.getElementById("facebookShare");


### PR DESCRIPTION
## Summary
- fix brand name in share text snippet in `public/script.js`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68844726b7ec8331974cf95f88749171