### PR TITLE
Fix error response headers

### DIFF
--- a/functions/getTerm/getTerm.js
+++ b/functions/getTerm/getTerm.js
@@ -12,6 +12,7 @@ exports.handler = async function (event) {
     if (!term || !terms[term]) {
       return {
         statusCode: 404,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ error: "Term not found" })
       };
     }
@@ -25,6 +26,7 @@ exports.handler = async function (event) {
     console.error("Function error:", err); // ✅ Helpful for logs in Netlify
     return {
       statusCode: 500,
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ error: "Server error" })
     };
   }


### PR DESCRIPTION
## Summary
- update Netlify function to return JSON content type for 404 and 500 errors

## Testing
- `node -e "require('./functions/getTerm/getTerm.js'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_688447385dec833194e779a58572693f